### PR TITLE
adding changes to allow index.js to accept an array of addon module…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,9 +7,21 @@
 		if( addons instanceof Array ){
 
 			for( var addon = 0, length = addons.length; addon < length; addon++ ){
+				
+				var additive = addons[addon];
+				
+				if (additive instanceof Function) {
+					additive(THREE);
+				}
 
-				require("./addons/" + addons[addon] + ".js")(THREE);
-
+				else if (typeof additive === "string") {
+					require("./addons/" + additive + ".js")(THREE);
+				}
+				
+				else {
+					throw new Error("Invalid module type provided");
+				}
+				
 			};
 
 		};


### PR DESCRIPTION
**Commit message:**
adding changes to allow index.js to accept an array of addon module functions, allowing it to play nicely with webpack environments.

**Full story:**
Webpack doesn't allow for dynamically generated strings when importing modules. Because of this, I had run into an issue where three-js would error out when I attempted to include addons in my webpack project.
The additions i've included, in an ES6+ / Babel / Webpack environment, would allow addons to be used like so:

``` javascript
import threeJS from 'three-js';
import Projector from 'three-js/addons/Projector';
import CanvasRenderer from 'three-js/addons/CanvasRenderer';
const THREE = threeJS([Projector, CanvasRenderer]);
```

Note that this is merely an addition to account for webpack users, and shouldn't interfere with any existing addon functionality.
